### PR TITLE
Switched to RxJS 5, fixed tests, rimraf

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "release:patch": "npm version patch && npm publish",
     "release:minor": "npm version minor && npm publish",
     "release:major": "npm version major && npm publish",
-    "compile": "rm -rf lib/ && babel -d lib/ src/",
+    "compile": "rimraf lib/ && babel -d lib/ src/",
     "watch": "babel --watch -d lib/ src/",
     "jshint": "jshint src/. test/. --config",
     "mocha": "mocha test/ --compilers js:babel-core/register",
@@ -43,16 +43,19 @@
   "dependencies": {
     "debug": "^2.2.0",
     "feathers-commons": "^0.7.1",
-    "rx": "^4.0.7"
+    "rxjs": "^5.0.0-beta.6"
   },
   "devDependencies": {
     "babel-cli": "^6.4.5",
     "babel-core": "^6.4.5",
     "babel-plugin-add-module-exports": "^0.1.2",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.7.7",
+    "babel-plugin-transform-function-bind": "^6.5.2",
     "babel-preset-es2015": "^6.3.13",
     "feathers": "^2.0.0",
     "feathers-memory": "^0.7.0",
     "jshint": "^2.9.1",
-    "mocha": "^2.3.4"
+    "mocha": "^2.3.4",
+    "rimraf": "^2.5.2"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
-import Rx from 'rx';
+import Rx from 'rxjs/Rx';
+
 import reactiveResource from './resource';
 import reactiveList from './list';
 

--- a/src/list.js
+++ b/src/list.js
@@ -1,4 +1,6 @@
-import Rx from 'rx';
+import Rx from 'rxjs/Rx';
+import 'rxjs/add/operator/exhaustMap';
+
 import { promisify } from './utils';
 import { sorter as createSorter, matcher } from 'feathers-commons/lib/utils';
 
@@ -19,7 +21,7 @@ export default function(events, options) {
     // The sort function (if $sort is set)
     const sorter = query.$sort ? createSorter(query.$sort) : null;
 
-    const stream = source.concat(source.flatMapFirst(data =>
+    const stream = source.concat(source.exhaustMap(data =>
       Rx.Observable.merge(
         events.created.filter(matches).map(eventData =>
           items => items.concat(eventData)

--- a/src/resource.js
+++ b/src/resource.js
@@ -1,4 +1,6 @@
-import Rx from 'rx';
+import Rx from 'rxjs/Rx';
+import 'rxjs/add/operator/exhaustMap';
+
 import { promisify } from './utils';
 
 export default function(events, options) {
@@ -11,7 +13,7 @@ export default function(events, options) {
     }
 
     const source = Rx.Observable.fromPromise(result);
-    const stream = source.concat(source.flatMapFirst(data => {
+    const stream = source.concat(source.exhaustMap(data => {
       // Filter only data with the same id
       const filter = current => current[options.id] === data[options.id];
       // `removed` events get special treatment

--- a/test/resource.test.js
+++ b/test/resource.test.js
@@ -37,8 +37,7 @@ describe('reactive resources', () => {
   });
 
   it('.update and .patch update existing stream', done => {
-    // TODO investigate why `debounce` is necessary
-    const result = service.get(id).debounce(0);
+    const result = service.get(id);
 
     result.first().subscribe(message => {
       assert.deepEqual(message, { id, text: 'A test message' });


### PR DESCRIPTION
Switched to RxJS 5 from 4 (so version is aligned with Angular and most other libraries). Added rimraf. The `debounce` is no longer required (at least according to the tests).