### PR TITLE
Added Strategy support

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "release:patch": "npm version patch && npm publish",
     "release:minor": "npm version minor && npm publish",
     "release:major": "npm version major && npm publish",
-    "compile": "rm -rf lib/ && babel -d lib/ src/",
+    "compile": "rimraf lib/ && babel -d lib/ src/",
     "watch": "babel --watch -d lib/ src/",
     "jshint": "jshint src/. test/. --config",
     "mocha": "mocha test/ --compilers js:babel-core/register",
@@ -43,16 +43,19 @@
   "dependencies": {
     "debug": "^2.2.0",
     "feathers-commons": "^0.7.1",
-    "rx": "^4.0.7"
+    "rxjs": "^5.0.0-beta.6"
   },
   "devDependencies": {
     "babel-cli": "^6.4.5",
     "babel-core": "^6.4.5",
     "babel-plugin-add-module-exports": "^0.1.2",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.7.7",
+    "babel-plugin-transform-function-bind": "^6.5.2",
     "babel-preset-es2015": "^6.3.13",
     "feathers": "^2.0.0",
     "feathers-memory": "^0.7.0",
     "jshint": "^2.9.1",
-    "mocha": "^2.3.4"
+    "mocha": "^2.3.4",
+    "rimraf": "^2.5.2"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
-import Rx from 'rx';
+import Rx from 'rxjs/Rx';
+
 import reactiveResource from './resource';
 import reactiveList from './list';
 

--- a/src/index.js
+++ b/src/index.js
@@ -5,9 +5,11 @@ import reactiveList from './list';
 
 const debug = require('debug')('feathers-rx');
 
-export default function(options) {
+function FeathersRx(options) {
   options = Object.assign({
     id: 'id',
+    // Whether to requery service when a change is detected
+    strategy: reactiveList.strategy.never,
     // The merging strategy
     merge(current, eventData) {
       return Object.assign({}, current, eventData);
@@ -46,3 +48,7 @@ export default function(options) {
     app.mixins.push(mixin);
   };
 }
+
+FeathersRx.strategy = reactiveList.strategy;
+
+export default FeathersRx;

--- a/src/list.js
+++ b/src/list.js
@@ -1,4 +1,6 @@
-import Rx from 'rx';
+import Rx from 'rxjs/Rx';
+import 'rxjs/add/operator/exhaustMap';
+
 import { promisify } from './utils';
 import { sorter as createSorter, matcher } from 'feathers-commons/lib/utils';
 
@@ -19,7 +21,7 @@ export default function(events, options) {
     // The sort function (if $sort is set)
     const sorter = query.$sort ? createSorter(query.$sort) : null;
 
-    const stream = source.concat(source.flatMapFirst(data =>
+    const stream = source.concat(source.exhaustMap(data =>
       Rx.Observable.merge(
         events.created.filter(matches).map(eventData =>
           items => items.concat(eventData)

--- a/src/list.js
+++ b/src/list.js
@@ -4,10 +4,12 @@ import 'rxjs/add/operator/exhaustMap';
 import { promisify } from './utils';
 import { sorter as createSorter, matcher } from 'feathers-commons/lib/utils';
 
-export default function(events, options) {
-  return function(params) {
+function List (events, options) {
+
+  return function (params) {
     const query = Object.assign({}, params.query);
     const result = this._super.apply(this, arguments);
+    const inputArgs = arguments;
 
     if(typeof result.then !== 'function') {
       return result;
@@ -21,30 +23,56 @@ export default function(events, options) {
     // The sort function (if $sort is set)
     const sorter = query.$sort ? createSorter(query.$sort) : null;
 
-    const stream = source.concat(source.exhaustMap(data =>
-      Rx.Observable.merge(
-        events.created.filter(matches).map(eventData =>
-          items => items.concat(eventData)
-        ),
-        events.removed.map(eventData =>
-          items => items.filter(current => eventData[options.id] !== current[options.id])
-        ),
-        updaters.map(eventData =>
-          items => items.map(current => {
-            if(eventData[options.id] === current[options.id]) {
-              return options.merge(current, eventData);
-            }
+    let stream;
 
-            return current;
-          }).filter(matches)
-        )
-      ).scan((current, callback) => {
-        const result = callback(current);
+    if (options.strategy === List.strategy.never) {
+      stream = source.concat(source.exhaustMap(data =>
+        Rx.Observable.merge(
+          events.created.filter(matches).map(eventData =>
+            items => items.concat(eventData)
+          ),
+          events.removed.map(eventData =>
+            items => items.filter(current => eventData[options.id] !== current[options.id])
+          ),
+          updaters.map(eventData =>
+            items => items.map(current => {
+              if(eventData[options.id] === current[options.id]) {
+                return options.merge(current, eventData);
+              }
 
-        return sorter ? result.sort(sorter) : result;
-      }, data)
-    ));
+              return current;
+            }).filter(matches)
+          )
+        ).scan((current, callback) => {
+          const result = callback(current);
+          return sorter ? result.sort(sorter) : result;
+        }, data)
+      ));
+    } else if (options.strategy === List.strategy.always) {
+      stream = source.concat(source.exhaustMap(() =>
+        Rx.Observable.merge(
+          events.created.filter(matches),
+          events.removed,
+          updaters
+        ).flatMap(() => {
+          return Rx.Observable.fromPromise(this.find.apply(this, inputArgs)).map((result) => {
+            return sorter ? result.sort(sorter) : result;
+          });
+        })
+      ));
+    } else {
+      throw 'Unsupported feathers-rx strategy type.';
+    }
 
     return promisify(stream, result);
   };
 }
+
+List.strategy = {
+  always: {},
+  never: {},
+  // TODO: Jack
+  // smart: {}
+};
+
+export default List;

--- a/src/list.js
+++ b/src/list.js
@@ -55,7 +55,12 @@ function List (events, options) {
           events.removed,
           updaters
         ).flatMap(() => {
-          return Rx.Observable.fromPromise(this.find.apply(this, inputArgs)).map((result) => {
+          const result = this.find.apply(this, inputArgs);
+          const source = Rx.Observable.fromPromise(result);
+          if(typeof result.then !== 'function') {
+            return Rx.Observable.of(result);
+          }
+          return source.map((result) => {
             return sorter ? result.sort(sorter) : result;
           });
         })

--- a/src/resource.js
+++ b/src/resource.js
@@ -1,4 +1,6 @@
-import Rx from 'rx';
+import Rx from 'rxjs/Rx';
+import 'rxjs/add/operator/exhaustMap';
+
 import { promisify } from './utils';
 
 export default function(events, options) {
@@ -11,7 +13,7 @@ export default function(events, options) {
     }
 
     const source = Rx.Observable.fromPromise(result);
-    const stream = source.concat(source.flatMapFirst(data => {
+    const stream = source.concat(source.exhaustMap(data => {
       // Filter only data with the same id
       const filter = current => current[options.id] === data[options.id];
       // `removed` events get special treatment

--- a/test/list.test.js
+++ b/test/list.test.js
@@ -7,159 +7,184 @@ import rx from '../src';
 describe('reactive lists', () => {
   let app, service;
 
-  beforeEach(done => {
-    app = feathers()
-      .configure(rx())
-      .use('/messages', memory());
+  describe('strategy.never', function () {
+    beforeEach(done => {
+      app = feathers()
+        .configure(rx({ strategy: rx.strategy.never }))
+        .use('/messages', memory());
 
-    service = app.service('messages');
+      service = app.service('messages');
 
-    service.create({
-      text: 'A test message'
-    }).then(() => done());
-  });
-
-  it('.find is promise compatible', done => {
-    service.find().then(messages => {
-      assert.deepEqual(messages, [ { text: 'A test message', id: 0 } ]);
-      done();
-    });
-  });
-
-  it('.find as an observable', done => {
-    service.find().first().subscribe(messages => {
-      assert.deepEqual(messages, [ { text: 'A test message', id: 0 } ]);
-      done();
-    });
-  });
-
-  it('.create and .find', done => {
-    service.find().skip(1).subscribe(messages => {
-      assert.deepEqual(messages, [
-        { text: 'A test message', id: 0 },
-        { text: 'Another message', id: 1 }
-      ]);
-      done();
-    });
-
-    setTimeout(() => service.create({ text: 'Another message' }), 20);
-  });
-
-  it('.update and .find', done => {
-    service.find().skip(1).subscribe(messages => {
-      assert.deepEqual(messages, [
-        { text: 'An updated test message', id: 0 }
-      ]);
-      done();
-    });
-
-    setTimeout(() => service.update(0, { text: 'An updated test message' }), 20);
-  });
-
-  it('.patch and .find', done => {
-    service.find().skip(1).subscribe(messages => {
-      assert.deepEqual(messages, [
-        { text: 'A patched test message', id: 0 }
-      ]);
-      done();
-    });
-
-    setTimeout(() => service.patch(0, { text: 'A patched test message' }), 20);
-  });
-
-  it('.remove and .find', done => {
-    service.find().skip(1).subscribe(messages => {
-      assert.deepEqual(messages, []);
-      done();
-    });
-
-    setTimeout(() => service.remove(0), 20);
-  });
-
-  it('.find with .create that matches', done => {
-    const result = service.find({ query: { counter: 1 } });
-
-    result.first().subscribe(messages => assert.deepEqual(messages, []));
-
-    result.skip(1).subscribe(messages => {
-      assert.deepEqual(messages, [{
-        id: 1,
-        text: 'New message',
-        counter: 1
-      }]);
-      done();
-    });
-
-    setTimeout(() => {
-      service.create([{
-        text: 'New message',
-        counter: 1
-      }, {
-        text: 'Other message',
-        counter: 2
-      }]);
-    }, 20);
-  });
-
-  it('.find with $sort, .create and .patch', done => {
-    const result = service.find({ query: { $sort: { text: -1 } } });
-
-    result.skip(1).first().subscribe(messages => {
-      assert.deepEqual(messages, [{
-        id: 1,
-        text: 'B test message'
-      }, {
-        id: 0,
-        text: 'A test message'
-      }]);
-    });
-
-    result.skip(2).first().subscribe(messages => {
-      assert.deepEqual(messages, [{
-        id: 0,
-        text: 'Updated test message'
-      }, {
-        id: 1,
-        text: 'B test message'
-      }]);
-
-      done();
-    });
-
-    setTimeout(() => {
       service.create({
-        text: 'B test message'
-      }).then(() =>
-        service.patch(0, {
-          text: 'Updated test message'
-        })
-      );
-    }, 20);
+        text: 'A test message'
+      }).then(() => done());
+    });
+
+    baseTests();
   });
 
-  it('removes item after .update/.patch if it does not match', done => {
-    Promise.all([
-      service.create({ text: 'first', counter: 1 }),
-      service.create({ text: 'second', counter: 1 })
-    ]).then(createdMessages => {
+  describe('strategy.always', function () {
+    beforeEach(done => {
+      app = feathers()
+        .configure(rx({ strategy: rx.strategy.always }))
+        .use('/messages', memory());
+
+      service = app.service('messages');
+
+      service.create({
+        text: 'A test message'
+      }).then(() => done());
+    });
+
+    baseTests();
+  });
+
+  function baseTests () {
+
+    it('.find is promise compatible', done => {
+      service.find().then(messages => {
+        assert.deepEqual(messages, [ { text: 'A test message', id: 0 } ]);
+        done();
+      });
+    });
+
+    it('.find as an observable', done => {
+      service.find().first().subscribe(messages => {
+        assert.deepEqual(messages, [ { text: 'A test message', id: 0 } ]);
+        done();
+      });
+    });
+
+    it('.create and .find', done => {
+      service.find().skip(1).subscribe(messages => {
+        assert.deepEqual(messages, [
+          { text: 'A test message', id: 0 },
+          { text: 'Another message', id: 1 }
+        ]);
+        done();
+      });
+
+      setTimeout(() => service.create({ text: 'Another message' }), 20);
+    });
+
+    it('.update and .find', done => {
+      service.find().skip(1).subscribe(messages => {
+        assert.deepEqual(messages, [
+          { text: 'An updated test message', id: 0 }
+        ]);
+        done();
+      });
+
+      setTimeout(() => service.update(0, { text: 'An updated test message' }), 20);
+    });
+
+    it('.patch and .find', done => {
+      service.find().skip(1).subscribe(messages => {
+        assert.deepEqual(messages, [
+          { text: 'A patched test message', id: 0 }
+        ]);
+        done();
+      });
+
+      setTimeout(() => service.patch(0, { text: 'A patched test message' }), 20);
+    });
+
+    it('.remove and .find', done => {
+      service.find().skip(1).subscribe(messages => {
+        assert.deepEqual(messages, []);
+        done();
+      });
+
+      setTimeout(() => service.remove(0), 20);
+    });
+
+    it('.find with .create that matches', done => {
       const result = service.find({ query: { counter: 1 } });
 
-      result.first().subscribe(messages =>
-        assert.deepEqual(messages, createdMessages)
-      );
+      result.first().subscribe(messages => assert.deepEqual(messages, []));
 
       result.skip(1).subscribe(messages => {
         assert.deepEqual(messages, [{
-          text: 'second',
-          counter: 1,
-          id: 2
+          id: 1,
+          text: 'New message',
+          counter: 1
         }]);
         done();
       });
 
       setTimeout(() => {
-        service.patch(1, { counter: 2 });
+        service.create([{
+          text: 'New message',
+          counter: 1
+        }, {
+          text: 'Other message',
+          counter: 2
+        }]);
       }, 20);
     });
-  });
+
+    it('.find with $sort, .create and .patch', done => {
+      const result = service.find({ query: { $sort: { text: -1 } } });
+
+      result.skip(1).first().subscribe(messages => {
+        assert.deepEqual(messages, [{
+          id: 1,
+          text: 'B test message'
+        }, {
+          id: 0,
+          text: 'A test message'
+        }]);
+      });
+
+      result.skip(2).first().subscribe(messages => {
+        assert.deepEqual(messages, [{
+          id: 0,
+          text: 'Updated test message'
+        }, {
+          id: 1,
+          text: 'B test message'
+        }]);
+
+        done();
+      });
+
+      setTimeout(() => {
+        service.create({
+          text: 'B test message'
+        }).then(() =>
+          service.patch(0, {
+            text: 'Updated test message'
+          })
+        );
+      }, 20);
+    });
+
+    it('removes item after .update/.patch if it does not match', done => {
+      Promise.all([
+        service.create({ text: 'first', counter: 1 }),
+        service.create({ text: 'second', counter: 1 })
+      ]).then(createdMessages => {
+        const result = service.find({ query: { counter: 1 } });
+
+        result.first().subscribe(messages =>
+          assert.deepEqual(messages, createdMessages)
+        );
+
+        result.skip(1).subscribe(messages => {
+          assert.deepEqual(messages, [{
+            text: 'second',
+            counter: 1,
+            id: 2
+          }]);
+          done();
+        });
+
+        setTimeout(() => {
+          service.patch(1, { counter: 2 });
+        }, 20);
+      });
+    });
+
+  }
+
 });

--- a/test/resource.test.js
+++ b/test/resource.test.js
@@ -37,8 +37,7 @@ describe('reactive resources', () => {
   });
 
   it('.update and .patch update existing stream', done => {
-    // TODO investigate why `debounce` is necessary
-    const result = service.get(id).debounce(0);
+    const result = service.get(id);
 
     result.first().subscribe(message => {
       assert.deepEqual(message, { id, text: 'A test message' });


### PR DESCRIPTION
The strategy that @daffl originally placed has been named `never` (since it never reruns a `find`) and I added an `always` which gets a fresh copy of all of the resources whenever a change to any of them has been detected.

Strategies are exposed via `rx.strategy`, like so:
```
var rx = require('feathers-rx);

feathers()
  .configure(rx({ strategy: rx.strategy.always })) // defaults to `never`
```