### PR TITLE
Remove direct RxJS dependency and have it passed to the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@
 const feathers = require('feathers');
 const memory = require('feathers-memory');
 const rx = require('feathers-rx');
+const RxJS = require('rxjs');
 
 const app = feathers()
-  .configure(rx())
+  .configure(rx(RxJS))
   .use('/messages', memory());
 
 const messages = app.service('messages');

--- a/examples/basic.js
+++ b/examples/basic.js
@@ -1,9 +1,10 @@
+const RxJS = require('rxjs');
 const feathers = require('feathers');
 const memory = require('feathers-memory');
 const rx = require('../lib');
 
 const app = feathers()
-  .configure(rx())
+  .configure(rx(RxJS))
   .use('/messages', memory());
 
 const messages = app.service('messages');

--- a/package.json
+++ b/package.json
@@ -43,8 +43,7 @@
   },
   "dependencies": {
     "debug": "^2.2.0",
-    "feathers-commons": "^0.7.1",
-    "rxjs": "^5.0.0-beta.6"
+    "feathers-commons": "^0.7.1"
   },
   "devDependencies": {
     "babel-cli": "^6.4.5",
@@ -60,6 +59,7 @@
     "feathers-memory": "^0.7.0",
     "jshint": "^2.9.1",
     "mocha": "^2.3.4",
-    "rimraf": "^2.5.2"
+    "rimraf": "^2.5.2",
+    "rxjs": "^5.0.0-beta.8"
   }
 }

--- a/src/list.js
+++ b/src/list.js
@@ -1,8 +1,6 @@
-import Rx from 'rxjs/Rx';
-import 'rxjs/add/operator/exhaustMap';
 import { promisify } from './utils';
 
-export default function(events, options) {
+export default function(Rx, events, options) {
   return function (params = {}) {
     const query = Object.assign({}, params.query);
     const result = this._super.apply(this, arguments);

--- a/src/resource.js
+++ b/src/resource.js
@@ -1,6 +1,3 @@
-import Rx from 'rxjs/Rx';
-import 'rxjs/add/operator/exhaustMap';
-
 import { promisify } from './utils';
 
 // The position of the params parameters for a service method so that we can extend them
@@ -10,7 +7,7 @@ export const paramsPositions = {
   patch: 2
 };
 
-export default function(events, settings, method) {
+export default function(Rx, events, settings, method) {
   return function() {
     const result = this._super.apply(this, arguments);
 

--- a/src/strategies.js
+++ b/src/strategies.js
@@ -1,72 +1,73 @@
-import Rx from 'rxjs/Rx';
 import { matcher } from 'feathers-commons/lib/utils';
 import { makeSorter } from './utils';
 
-export default {
-  never(source) {
-    return source;
-  },
+export default function(Rx) {
+  return {
+    never(source) {
+      return source;
+    },
 
-  always(source, events, options, args) {
-    const params = args[0] || {};
-    const query = Object.assign({}, params.query);
-    const _super = this._super.bind(this);
+    always(source, events, options, args) {
+      const params = args[0] || {};
+      const query = Object.assign({}, params.query);
+      const _super = this._super.bind(this);
 
-    // A function that returns if an item matches the query
-    const matches = matcher(query);
-    // A function that sorts a limits a result (paginated or not)
-    const sortAndTrim = makeSorter(query, options);
+      // A function that returns if an item matches the query
+      const matches = matcher(query);
+      // A function that sorts a limits a result (paginated or not)
+      const sortAndTrim = makeSorter(query, options);
 
-    return source.concat(source.exhaustMap(() =>
-      Rx.Observable.merge(
-        events.created.filter(matches),
-        events.removed,
-        Rx.Observable.merge(events.updated, events.patched)
-      ).flatMap(() => {
-        const result = _super(...args);
-        const source = Rx.Observable.fromPromise(result);
+      return source.concat(source.exhaustMap(() =>
+        Rx.Observable.merge(
+          events.created.filter(matches),
+          events.removed,
+          Rx.Observable.merge(events.updated, events.patched)
+        ).flatMap(() => {
+          const result = _super(...args);
+          const source = Rx.Observable.fromPromise(result);
 
-        return source.map(sortAndTrim);
-      })
-    ));
-  },
+          return source.map(sortAndTrim);
+        })
+      ));
+    },
 
-  smart(source, events, options, args) {
-    const params = args[0] || {};
-    const query = Object.assign({}, params.query);
-    // A function that returns if an item matches the query
-    const matches = matcher(query);
-    // A function that sorts a limits a result (paginated or not)
-    const sortAndTrim = makeSorter(query, options);
+    smart(source, events, options, args) {
+      const params = args[0] || {};
+      const query = Object.assign({}, params.query);
+      // A function that returns if an item matches the query
+      const matches = matcher(query);
+      // A function that sorts a limits a result (paginated or not)
+      const sortAndTrim = makeSorter(query, options);
 
-    return source.concat(source.exhaustMap(data =>
-      Rx.Observable.merge(
-        events.created.filter(matches).map(eventData =>
-          items => items.concat(eventData)
-        ),
-        events.removed.map(eventData =>
-          items => items.filter(current =>
-            eventData[options.idField] !== current[options.idField]
+      return source.concat(source.exhaustMap(data =>
+        Rx.Observable.merge(
+          events.created.filter(matches).map(eventData =>
+            items => items.concat(eventData)
+          ),
+          events.removed.map(eventData =>
+            items => items.filter(current =>
+              eventData[options.idField] !== current[options.idField]
+            )
+          ),
+          Rx.Observable.merge(events.updated, events.patched).map(eventData =>
+            items => items.map(current => {
+              if(eventData[options.idField] === current[options.idField]) {
+                return options.merge(current, eventData);
+              }
+
+              return current;
+            }).filter(matches)
           )
-        ),
-        Rx.Observable.merge(events.updated, events.patched).map(eventData =>
-          items => items.map(current => {
-            if(eventData[options.idField] === current[options.idField]) {
-              return options.merge(current, eventData);
-            }
-
-            return current;
-          }).filter(matches)
-        )
-      ).scan((current, callback) => {
-        const isPaginated = !!current[options.dataField];
-        if (isPaginated) {
-          current[options.dataField] = callback(current.data);
-        } else {
-          current = callback(current);
-        }
-        return sortAndTrim(current);
-      }, data)
-    ));
-  }
-};
+        ).scan((current, callback) => {
+          const isPaginated = !!current[options.dataField];
+          if (isPaginated) {
+            current[options.dataField] = callback(current.data);
+          } else {
+            current = callback(current);
+          }
+          return sortAndTrim(current);
+        }, data)
+      ));
+    }
+  };
+}

--- a/test/list.test.js
+++ b/test/list.test.js
@@ -1,3 +1,4 @@
+import Rx from 'rxjs/Rx';
 import assert from 'assert';
 import feathers from 'feathers';
 import memory from 'feathers-memory';
@@ -11,7 +12,7 @@ describe('reactive lists', () => {
     describe('default', function () {
       beforeEach(done => {
         app = feathers()
-          .configure(rx())
+          .configure(rx(Rx))
           .use('/messages', memory());
 
         service = app.service('messages').rx();
@@ -27,7 +28,7 @@ describe('reactive lists', () => {
     describe('custom id', function () {
       beforeEach(done => {
         app = feathers()
-          .configure(rx())
+          .configure(rx(Rx))
           .use('/messages', memory({ idField: 'customId' }));
 
         service = app.service('messages').rx({idField: 'customId'});
@@ -43,7 +44,7 @@ describe('reactive lists', () => {
     describe('pagination', function () {
       beforeEach(done => {
         app = feathers()
-          .configure(rx())
+          .configure(rx(Rx))
           .use('/messages', memory({ paginate: { default: 3 }}));
 
         service = app.service('messages').rx();
@@ -61,8 +62,8 @@ describe('reactive lists', () => {
     describe('default', function () {
       beforeEach(done => {
         app = feathers()
-          .configure(rx({
-            listStrategy: rx.strategy.always
+          .configure(rx(Rx, {
+            listStrategy: 'always'
           }))
           .use('/messages', memory());
 
@@ -79,8 +80,8 @@ describe('reactive lists', () => {
     describe('custom id', function () {
       beforeEach(done => {
         app = feathers()
-          .configure(rx({
-            listStrategy: rx.strategy.always
+          .configure(rx(Rx, {
+            listStrategy: 'always'
           }))
           .use('/messages', memory({ idField: 'customId' }));
 
@@ -97,8 +98,8 @@ describe('reactive lists', () => {
     describe('pagination', function () {
       beforeEach(done => {
         app = feathers()
-          .configure(rx({
-            listStrategy: rx.strategy.always
+          .configure(rx(Rx, {
+            listStrategy: 'always'
           }))
           .use('/messages', memory({ paginate: { default: 3 }}));
 

--- a/test/resource.test.js
+++ b/test/resource.test.js
@@ -1,3 +1,4 @@
+import Rx from 'rxjs/Rx';
 import assert from 'assert';
 import feathers from 'feathers';
 import memory from 'feathers-memory';
@@ -11,7 +12,7 @@ describe('reactive resources', () => {
   describe('standard id', function () {
     beforeEach(done => {
       app = feathers()
-        .configure(rx())
+        .configure(rx(Rx))
         .use('/messages', memory());
 
       service = app.service('messages').rx({idField: 'customId'});
@@ -29,7 +30,7 @@ describe('reactive resources', () => {
   describe('custom id on service', function () {
     beforeEach(done => {
       app = feathers()
-        .configure(rx())
+        .configure(rx(Rx))
         .use('/messages', memory({ idField: 'customId' }));
 
       service = app.service('messages').rx({ idField: 'customId' });
@@ -48,7 +49,7 @@ describe('reactive resources', () => {
   describe('custom id on params', function () {
     beforeEach(done => {
       app = feathers()
-        .configure(rx())
+        .configure(rx(Rx))
         .configure(hooks())
         .use('/messages', memory({ idField: 'customId' }));
 


### PR DESCRIPTION
That way you can use RxJS whichever way you want, it removes the hard dependency on RxJS and gets the (unminified) Browserified size down from 550k to 25k. The only thing you have to do now is pass it to the `rx` method when configuring:

```js
import RxJS from 'rxjs';

app.configure(rx(RxJS, options));
```

@harangue Let me know if you see an issue with this.